### PR TITLE
fix: [VIC-404] use fallback text color for all cases where the primary color is used on bright background

### DIFF
--- a/src/components/agencySelection/agencySelection.styles.scss
+++ b/src/components/agencySelection/agencySelection.styles.scss
@@ -49,7 +49,7 @@ $infoIconSize: 16px;
 
 		&--warning {
 			.text__infoSmall {
-				color: var(--skin-color-primary, $primary);
+				color: var(--skin-color-primary-contrast-safe, $primary);
 			}
 
 			a {

--- a/src/components/app/authenticatedApp.styles.scss
+++ b/src/components/app/authenticatedApp.styles.scss
@@ -7,7 +7,7 @@ $contentWidth: calc((100vw - #{$navWidth}) / 12 * 8);
 $headerHeight: $grid-base-twelve;
 
 a {
-	color: var(--skin-color-primary, $primary);
+	color: var(--skin-color-primary-contrast-safe, $primary);
 }
 
 .app {

--- a/src/components/app/navigation.styles.scss
+++ b/src/components/app/navigation.styles.scss
@@ -76,7 +76,7 @@ $unreadBubbleAnimation: count 500ms ease 500ms forwards;
 		}
 
 		&__count {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 			background-color: $white;
 			opacity: 0.7;
 			transition: opacity 0.6s ease;

--- a/src/components/button/button.styles.scss
+++ b/src/components/button/button.styles.scss
@@ -109,7 +109,7 @@ $buttonHeight: 50px;
 	}
 
 	&__link {
-		color: var(--skin-color-link, $primary);
+		color: var(--skin-color-primary-contrast-safe, $primary);
 		background: none;
 		height: 21px;
 
@@ -118,10 +118,10 @@ $buttonHeight: 50px;
 		}
 
 		&:not([disabled]):hover {
-			color: var(--skin-color-link, $hover-primary);
+			color: var(--skin-color-primary-contrast-safe, $hover-primary);
 
 			svg * {
-				fill: var(--skin-color-link, $hover-primary);
+				fill: var(--skin-color-primary-contrast-safe, $hover-primary);
 			}
 		}
 

--- a/src/components/datepicker/datepicker.styles.scss
+++ b/src/components/datepicker/datepicker.styles.scss
@@ -147,10 +147,13 @@ $arrow-icon-size: 14px;
 		&__month-text--today,
 		&__quarter-text--today {
 			font-weight: $font-weight-medium;
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 
 			&:hover {
-				color: var(--skin-color-primary, $primary) !important;
+				color: var(
+					--skin-color-primary-contrast-safe,
+					$primary
+				) !important;
 			}
 		}
 
@@ -207,7 +210,7 @@ $arrow-icon-size: 14px;
 			border-radius: 0;
 
 			&:hover {
-				color: var(--skin-color-primary, $primary);
+				color: var(--skin-color-primary-contrast-safe, $primary);
 				background-color: $datepicker-hover-color;
 			}
 		}

--- a/src/components/message/message.styles.scss
+++ b/src/components/message/message.styles.scss
@@ -28,7 +28,7 @@ $message-attachment-color: $secondary !default;
 		text-decoration: underline;
 
 		&:hover {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 			transition: unset;
 		}
 
@@ -127,7 +127,7 @@ $message-attachment-color: $secondary !default;
 		}
 
 		&--lastRead {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 
 			&::before,
 			&::after {

--- a/src/components/messageSubmitInterface/emojiPicker.styles.scss
+++ b/src/components/messageSubmitInterface/emojiPicker.styles.scss
@@ -179,7 +179,7 @@ $emoji-popover-height: 433px;
 		outline: none;
 	}
 	.emoji__selectPopover__navEntry--active {
-		color: var(--skin-color-primary, $primary);
+		color: var(--skin-color-primary-contrast-safe, $primary);
 	}
 	.emoji__selectPopover__scrollbar {
 		position: absolute;

--- a/src/components/monitoring/monitoring.styles.scss
+++ b/src/components/monitoring/monitoring.styles.scss
@@ -116,7 +116,7 @@
 					left: -16px;
 					z-index: 1;
 					border-bottom: 1px solid transparent;
-					color: var(--skin-color-primary, $primary);
+					color: var(--skin-color-primary-contrast-safe, $primary);
 				}
 			}
 		}
@@ -144,7 +144,7 @@
 				left: -16px;
 				z-index: 1;
 				border-bottom: 1px solid transparent;
-				color: var(--skin-color-primary, $primary);
+				color: var(--skin-color-primary-contrast-safe, $primary);
 			}
 		}
 

--- a/src/components/overlay/overlay.styles.scss
+++ b/src/components/overlay/overlay.styles.scss
@@ -93,7 +93,7 @@ $overlay-icon-size-large: 48px !default;
 		margin: 0 auto 36px;
 
 		.text {
-			color: var(--skin-color-link, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 			text-transform: uppercase;
 			display: none;
 

--- a/src/components/passwordReset/passwordReset.styles.scss
+++ b/src/components/passwordReset/passwordReset.styles.scss
@@ -92,7 +92,7 @@
 		font-weight: $font-weight-bold;
 		text-transform: uppercase;
 		cursor: pointer;
-		color: var(--skin-color-primary, $primary);
+		color: var(--skin-color-primary-contrast-safe, $primary);
 		text-decoration: none;
 		transition: all 0.6s ease;
 		margin-left: auto;

--- a/src/components/profile/twoFactorAuth.styles.scss
+++ b/src/components/profile/twoFactorAuth.styles.scss
@@ -72,14 +72,17 @@ $two-factor-auth-overlay-buttons-margin-right: auto !default;
 			justify-items: start;
 			cursor: pointer;
 			margin-top: $grid-base-two;
-			color: var(--skin-color-link, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 
 			.text {
-				color: var(--skin-color-link, $primary);
+				color: var(--skin-color-primary-contrast-safe, $primary);
 				margin: auto 0 auto $grid-base;
 
 				&:hover {
-					color: var(--skin-color-link, $hover-primary);
+					color: var(
+						--skin-color-primary-contrast-safe,
+						$hover-primary
+					);
 				}
 			}
 		}

--- a/src/components/sessionHeader/sessionHeader.styles.scss
+++ b/src/components/sessionHeader/sessionHeader.styles.scss
@@ -168,7 +168,10 @@ $iconSize: 24px;
 			}
 
 			&--red {
-				color: var(--skin-color-primary, $primary) !important;
+				color: var(
+					--skin-color-primary-contrast-safe,
+					$primary
+				) !important;
 				text-transform: uppercase;
 			}
 

--- a/src/components/tagSelect/tagSelect.styles.scss
+++ b/src/components/tagSelect/tagSelect.styles.scss
@@ -12,7 +12,7 @@
 		transition: all ease 0.5s;
 
 		&:hover + .tagSelect__label {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 			background-color: $background-accent;
 		}
 
@@ -24,7 +24,7 @@
 		}
 
 		&:checked + .tagSelect__label {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 			background-color: $hover-select;
 		}
 	}
@@ -42,7 +42,7 @@
 		transition: all ease 0.5s;
 
 		&:hover {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 			background-color: $hover-select;
 		}
 

--- a/src/components/text/text.styles.scss
+++ b/src/components/text/text.styles.scss
@@ -52,7 +52,7 @@
 		}
 
 		&--notice {
-			color: var(--skin-color-primary, $primary);
+			color: var(--skin-color-primary-contrast-safe, $primary);
 		}
 	}
 

--- a/src/components/typingIndicator/typingIndicator.styles.scss
+++ b/src/components/typingIndicator/typingIndicator.styles.scss
@@ -11,7 +11,7 @@ $indicator-height: 29px;
 	z-index: 2;
 
 	&__text {
-		color: var(--skin-color-primary, $primary);
+		color: var(--skin-color-primary-contrast-safe, $primary);
 		font-size: $font-size-secondary;
 		line-height: $line-height-secondary;
 		margin-right: $grid-base;

--- a/src/utils/useTenantTheming.ts
+++ b/src/utils/useTenantTheming.ts
@@ -109,6 +109,11 @@ const injectCss = ({ primaryColor, secondaryColor }) => {
 			? secondaryColor
 			: 'var(--skin-color-default)';
 
+	const primaryColorContrastSafe =
+		primaryHSL.l > contrastThreshold
+			? 'var(--skin-color-primary-foreground-dark)'
+			: primaryColor;
+
 	document.head.insertAdjacentHTML(
 		'beforeend',
 		`<style>
@@ -131,11 +136,7 @@ const injectCss = ({ primaryColor, secondaryColor }) => {
 			adjust: 90
 		})};
 		--skin-color-secondary-contrast-safe: ${secondaryColorContrastSafe};
-		--skin-color-link: ${
-			primaryHSL.l > contrastThreshold
-				? 'var(--skin-color-primary-foreground-dark)'
-				: primaryColor
-		};
+		--skin-color-primary-contrast-safe: ${primaryColorContrastSafe};
 		--text-color-contrast-switch: ${textColorContrastSwitch};
 		--text-color-secondary-contrast-switch: ${textColorSecondaryContrastSwitch};
 		}


### PR DESCRIPTION
This was the original bug report:

<img width="385" alt="Screenshot 2022-02-25 at 15 10 38" src="https://user-images.githubusercontent.com/4038316/155729385-3bd42ec0-6a4c-462f-92f5-b2f5a3cbe82b.png">

There were however a few more cases where the primary color might be problematic, so this addresses them.

Changes:
 - Rename `--skin-color-link` to `--skin-color-primary-contrast-safe` (since it's not only used for links)
 - Use `--skin-color-primary-contrast-safe` for all cases where the primary color is used for text on bright background

Related theme upgrade: https://github.com/virtualidentityag/vi-saas-frontend-theme/pull/32